### PR TITLE
feat: implement search

### DIFF
--- a/src/modules/search/components/__tests__/search-input.test.tsx
+++ b/src/modules/search/components/__tests__/search-input.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { SearchInput } from '../search-input';
+
+describe('SearchInput', () => {
+  it('renders with default placeholder', () => {
+    const mockOnChange = vi.fn();
+    
+    render(<SearchInput value="" onChange={mockOnChange} />);
+    
+    const inputElement = screen.getByTestId('search-input');
+    expect(inputElement).toBeDefined();
+    expect(inputElement.getAttribute('placeholder')).toBe('Search...');
+  });
+  
+  it('renders with custom placeholder', () => {
+    const mockOnChange = vi.fn();
+    const customPlaceholder = 'Find users...';
+    
+    render(<SearchInput value="" onChange={mockOnChange} placeholder={customPlaceholder} />);
+    
+    const inputElement = screen.getByTestId('search-input');
+    expect(inputElement.getAttribute('placeholder')).toBe(customPlaceholder);
+  });
+  
+  it('displays the provided value', () => {
+    const mockOnChange = vi.fn();
+    const testValue = 'test query';
+    
+    render(<SearchInput value={testValue} onChange={mockOnChange} />);
+    
+    const inputElement = screen.getByTestId('search-input');
+    expect(inputElement.getAttribute('value')).toBe(testValue);
+  });
+  
+  it('calls onChange handler when input changes', () => {
+    const mockOnChange = vi.fn();
+    
+    render(<SearchInput value="" onChange={mockOnChange} />);
+    
+    const inputElement = screen.getByTestId('search-input');
+    const testValue = 'new search';
+    
+    fireEvent.change(inputElement, { target: { value: testValue } });
+    
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    expect(mockOnChange).toHaveBeenCalledWith(testValue);
+  });
+});

--- a/src/modules/search/components/search-input.tsx
+++ b/src/modules/search/components/search-input.tsx
@@ -1,0 +1,26 @@
+interface SearchInputProps {
+  value: string;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}
+
+export const SearchInput: React.FC<SearchInputProps> = ({
+  value,
+  onChange,
+  placeholder = 'Search...',
+}) => {
+  return (
+    <div className="mb-6">
+      <div className="flex gap-2">
+        <input
+          type="text"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          placeholder={placeholder}
+          className="flex-grow px-4 py-2 bg-gray-700 text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+          data-testid="search-input"
+        />
+      </div>
+    </div>
+  );
+};

--- a/src/modules/search/hooks/__tests__/useDebounce.test.tsx
+++ b/src/modules/search/hooks/__tests__/useDebounce.test.tsx
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useDebounce } from '../useDebounce';
+import { afterEach } from 'node:test';
+
+describe('useDebounce', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('should return the initial value immediately', () => {
+    const initialValue = 'initial';
+    const { result } = renderHook(() => useDebounce(initialValue, 500));
+    
+    expect(result.current).toBe(initialValue);
+  });
+
+  it('should not update the value before the delay period', () => {
+    const initialValue = 'initial';
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: initialValue, delay: 500 } }
+    );
+    
+    // Change the value
+    rerender({ value: 'updated', delay: 500 });
+    
+    // Advance time but not enough to trigger the update
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+    
+    // Value should still be the initial value
+    expect(result.current).toBe(initialValue);
+  });
+
+  it('should update the value after the delay period', () => {
+    const initialValue = 'initial';
+    const updatedValue = 'updated';
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: initialValue, delay: 500 } }
+    );
+    
+    // Change the value
+    rerender({ value: updatedValue, delay: 500 });
+    
+    // Advance time enough to trigger the update
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    
+    // Value should be updated
+    expect(result.current).toBe(updatedValue);
+  });
+
+  it('should handle multiple value changes within the delay period', () => {
+    const initialValue = 'initial';
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: initialValue, delay: 500 } }
+    );
+    
+    // Change the value multiple times
+    rerender({ value: 'intermediate1', delay: 500 });
+    
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    
+    rerender({ value: 'intermediate2', delay: 500 });
+    
+    act(() => {
+      vi.advanceTimersByTime(200);
+    });
+    
+    rerender({ value: 'final', delay: 500 });
+    
+    // Value should still be the initial value
+    expect(result.current).toBe(initialValue);
+    
+    // Advance time enough to trigger the update
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    
+    // Value should be the final value
+    expect(result.current).toBe('final');
+  });
+
+  it('should handle delay changes', () => {
+    const initialValue = 'initial';
+    const updatedValue = 'updated';
+    const { result, rerender } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: initialValue, delay: 1000 } }
+    );
+    
+    // Change the value and reduce the delay
+    rerender({ value: updatedValue, delay: 300 });
+    
+    // Advance time enough for the new delay
+    act(() => {
+      vi.advanceTimersByTime(300);
+    });
+    
+    // Value should be updated
+    expect(result.current).toBe(updatedValue);
+  });
+
+  it('should clear timeout on unmount', () => {
+    const clearTimeoutSpy = vi.spyOn(global, 'clearTimeout');
+    
+    const { unmount } = renderHook(
+      ({ value, delay }) => useDebounce(value, delay),
+      { initialProps: { value: 'test', delay: 500 } }
+    );
+    
+    unmount();
+    
+    // Cleanup function should have been called
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/src/modules/search/hooks/useDebounce.ts
+++ b/src/modules/search/hooks/useDebounce.ts
@@ -1,0 +1,17 @@
+import { useState, useEffect } from 'react';
+
+export function useDebounce<T>(value: T, delay: number): T {
+  const [debouncedValue, setDebouncedValue] = useState<T>(value);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}

--- a/src/modules/users/components/__tests__/user-detail.test.tsx
+++ b/src/modules/users/components/__tests__/user-detail.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { UserDetail } from '../user-detail';
-import { GitHubUserDetail } from '../../github-types';
+import { GitHubUser } from '../../github-types';
 import { mockUserDetail } from '../../mocks/github-users-mock';
 
 // Mock the next/image component
@@ -18,7 +18,7 @@ vi.mock('next/image', () => ({
 }));
 
 describe('UserDetail', () => {
-  const mockUser: GitHubUserDetail = mockUserDetail;
+  const mockUser: GitHubUser = mockUserDetail;
 
   it('renders the user detail with correct information', () => {
     render(<UserDetail user={mockUser} />);

--- a/src/modules/users/components/__tests__/user-list.test.tsx
+++ b/src/modules/users/components/__tests__/user-list.test.tsx
@@ -50,12 +50,10 @@ describe('UserList', () => {
       refetch: vi.fn(),
     });
     
-    render(<UserList />, { wrapper: createQueryWrapper() });
+    render(<UserList searchQuery="" />, { wrapper: createQueryWrapper() });
     
     // Check if loading indicator is shown
     expect(screen.getByTestId('loading-spinner')).toBeInTheDocument();
-    // Alternatively, if you use a specific test ID:
-    // expect(screen.getByTestId('loading-indicator')).toBeInTheDocument();
   });
 
   it('should render users when data is loaded', async () => {
@@ -67,7 +65,7 @@ describe('UserList', () => {
       refetch: vi.fn(),
     });
     
-    render(<UserList />, { wrapper: createQueryWrapper() });
+    render(<UserList searchQuery="" />, { wrapper: createQueryWrapper() });
     
     // Check if all users are rendered
     mockUsers.forEach(user => {
@@ -85,7 +83,7 @@ describe('UserList', () => {
       refetch: vi.fn(),
     });
     
-    render(<UserList />, { wrapper: createQueryWrapper() });
+    render(<UserList searchQuery="" />, { wrapper: createQueryWrapper() });
     
     // Check if error message is shown
     expect(screen.getByText(/Error loading users/i)).toBeInTheDocument();
@@ -105,7 +103,7 @@ describe('UserList', () => {
       refetch: vi.fn(),
     });
     
-    render(<UserList />, { wrapper: createQueryWrapper() });
+    render(<UserList searchQuery="" />, { wrapper: createQueryWrapper() });
     
     // Check if empty state message is shown
     expect(screen.getByText(/No users found/i)).toBeInTheDocument();
@@ -123,7 +121,7 @@ describe('UserList', () => {
       refetch: mockRefetch,
     });
     
-    render(<UserList />, { wrapper: createQueryWrapper() });
+    render(<UserList searchQuery="" />, { wrapper: createQueryWrapper() });
     
     // Find and click the retry button
     const retryButton = screen.getByRole('button', { name: /retry/i });
@@ -131,5 +129,21 @@ describe('UserList', () => {
     
     // Verify refetch was called
     expect(mockRefetch).toHaveBeenCalledTimes(1);
+  });
+  
+  it('should pass search query to useGitHubUsers hook', () => {
+    // Mock hook to return empty array
+    mockUseGitHubUsers.mockReturnValue({
+      users: [],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    
+    const searchQuery = 'test query';
+    render(<UserList searchQuery={searchQuery} />, { wrapper: createQueryWrapper() });
+    
+    // Verify that the hook was called with the correct search query
+    expect(mockUseGitHubUsers).toHaveBeenCalledWith(searchQuery);
   });
 });

--- a/src/modules/users/components/user-detail.tsx
+++ b/src/modules/users/components/user-detail.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
 import Image from 'next/image';
-import { GitHubUserDetail } from '../github-types';
+import { GitHubUser } from '../github-types';
 import { UserFavorite } from './user-favorite';
 
 interface UserDetailProps {
-  user?: GitHubUserDetail;
+  user?: GitHubUser;
 }
 
 export const UserDetail: React.FC<UserDetailProps> = ({ user }) => {
@@ -186,7 +186,7 @@ export const UserDetail: React.FC<UserDetailProps> = ({ user }) => {
                   Following ({user.following})
                 </a>
               </li>
-              {user.public_gists > 0 && (
+              {user.public_gists && (
                 <li>
                   <a 
                     href={`https://gist.github.com/${user.login}`} 

--- a/src/modules/users/components/user-list.tsx
+++ b/src/modules/users/components/user-list.tsx
@@ -1,8 +1,12 @@
 import { UserCard } from './user-card';
 import { useGitHubUsers } from '../hooks/useGitHubUsers';
 
-export const UserList: React.FC = () => {
-  const { users, isLoading, error, refetch } = useGitHubUsers();
+interface UserListProps {
+  searchQuery: string;
+}
+
+export const UserList: React.FC<UserListProps> = ({ searchQuery }) => {
+  const { users, isLoading, error, refetch } = useGitHubUsers(searchQuery);
 
   if (isLoading) {
     return (

--- a/src/modules/users/github-types.ts
+++ b/src/modules/users/github-types.ts
@@ -18,40 +18,18 @@ export interface GitHubUser {
   type: string;
   user_view_type: string;
   site_admin: boolean;
-}
-
-export interface GitHubUserDetail {
-  login: string;
-  id: number;
-  node_id: string;
-  avatar_url: string;
-  gravatar_id: string;
-  url: string;
-  html_url: string;
-  followers_url: string;
-  following_url: string;
-  gists_url: string;
-  starred_url: string;
-  subscriptions_url: string;
-  organizations_url: string;
-  repos_url: string;
-  events_url: string;
-  received_events_url: string;
-  type: string;
-  user_view_type: string;
-  site_admin: boolean;
-  name: string;
-  company: string;
-  blog: string;
-  location: string;
-  email: string | null;
-  hireable: boolean | null;
-  bio: string;
-  twitter_username: string;
-  public_repos: number;
-  public_gists: number;
-  followers: number;
-  following: number;
-  created_at: string;
-  updated_at: string;
+  name?: string;
+  company?: string;
+  blog?: string;
+  location?: string;
+  email?: string | null;
+  hireable?: boolean | null;
+  bio?: string;
+  twitter_username?: string;
+  public_repos?: number;
+  public_gists?: number;
+  followers?: number;
+  following?: number;
+  created_at?: string;
+  updated_at?: string;
 }

--- a/src/modules/users/hooks/useGitHubUserDetails.ts
+++ b/src/modules/users/hooks/useGitHubUserDetails.ts
@@ -1,10 +1,10 @@
 import { useQuery, UseQueryOptions } from '@tanstack/react-query';
-import { GitHubUserDetail } from '../github-types';
+import { GitHubUser } from '../github-types';
 import githubService, { githubQueryKeys } from '../services/github-api';
 
-export const useGitHubUserDetails = <T = GitHubUserDetail>(
+export const useGitHubUserDetails = <T = GitHubUser>(
   username: string,
-  options?: Partial<UseQueryOptions<GitHubUserDetail, Error, T>>
+  options?: Partial<UseQueryOptions<GitHubUser, Error, T>>
 ) => {
   const {
     data: user,

--- a/src/modules/users/hooks/useGitHubUsers.ts
+++ b/src/modules/users/hooks/useGitHubUsers.ts
@@ -3,16 +3,26 @@ import { GitHubUser } from '../github-types';
 import githubService, { githubQueryKeys } from '../services/github-api';
 
 export const useGitHubUsers = <T = GitHubUser[]>(
+  query: string,
   options?: UseQueryOptions<GitHubUser[], Error, T>
 ) => {
+
+  const { queryKey, queryFn } = query.length > 0 ? {
+    queryKey: githubQueryKeys.searchUsers(query),
+    queryFn: () => githubService.searchUsers(query),
+  } : {
+    queryKey: githubQueryKeys.users(),
+    queryFn: () => githubService.getUsers(),
+  };
+
   const {
     data: users = [],
     isLoading,
     error,
     refetch,
   } = useQuery({
-    queryKey: githubQueryKeys.users(),
-    queryFn: () => githubService.getUsers(),
+    queryKey,
+    queryFn,
     ...options,
   });
 

--- a/src/modules/users/mocks/github-users-mock.ts
+++ b/src/modules/users/mocks/github-users-mock.ts
@@ -1,4 +1,4 @@
-import { GitHubUser, GitHubUserDetail } from '../github-types';
+import { GitHubUser } from '../github-types';
 
 export const mockUsers: GitHubUser[] = [
   {
@@ -66,7 +66,7 @@ export const mockUsers: GitHubUser[] = [
   }
 ];
 
-export const mockUserDetail: GitHubUserDetail = {
+export const mockUserDetail: GitHubUser = {
   login: 'testuser',
   id: 1,
   node_id: 'MDQ6VXNlcjE=',

--- a/src/modules/users/pages/users-page.tsx
+++ b/src/modules/users/pages/users-page.tsx
@@ -1,12 +1,27 @@
+import { useState } from 'react';
 import { UserList } from '../components';
+import { SearchInput } from '@/modules/search/components/search-input';
+import { useDebounce } from '@/modules/search/hooks/useDebounce';
 
-export default function UsersPage() {
+export default function UsersPage(): JSX.Element {
+  const [searchTerm, setSearchTerm] = useState('');
+  const debouncedSearchTerm = useDebounce<string>(searchTerm, 500); // 500ms debounce delay
+
   return (
     <main className="container mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-6" data-testid="page-title">
         GitHub Users
       </h1>
-      <UserList />
+      
+      <SearchInput
+        value={searchTerm}
+        onChange={setSearchTerm}
+        placeholder="Search GitHub users..."
+      />
+      
+      <UserList 
+        searchQuery={debouncedSearchTerm} 
+      />
     </main> 
   );
 }

--- a/src/modules/users/services/__tests__/github-api.test.ts
+++ b/src/modules/users/services/__tests__/github-api.test.ts
@@ -49,7 +49,6 @@ describe('GitHubService', () => {
     });
   });
 
-  // Add tests for getUserDetails method
   describe('getUserDetails', () => {
     it('should fetch user details successfully', async () => {
       // Mock successful response
@@ -102,4 +101,72 @@ describe('GitHubService', () => {
       expect(mockFetch).toHaveBeenCalledWith(`https://api.github.com/users/${encodeURIComponent(usernameWithSpecialChars)}`);
     });
   });
+
+  describe('searchUsers', () => {
+    it('should search users successfully', async () => {
+      // Create mock search response
+      const mockSearchResponse = {
+        items: mockUsers,
+        total_count: mockUsers.length,
+        incomplete_results: false
+      };
+
+      // Mock successful response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSearchResponse,
+      });
+
+      const query = 'test';
+      const searchResults = await githubService.searchUsers(query);
+      
+      // Assert fetch was called correctly with the right query
+      expect(mockFetch).toHaveBeenCalledWith(`https://api.github.com/search/users?q=${encodeURIComponent(query)}`);
+      
+      // Assert the result matches our mock data
+      expect(searchResults).toEqual(mockUsers);
+    });
+
+    it('should handle API errors when searching users', async () => {
+      // Mock error response
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        statusText: 'Unprocessable Entity',
+      });
+
+      // Assert that the service throws an error
+      await expect(githubService.searchUsers('invalid query')).rejects.toThrow('GitHub API error: 422 Unprocessable Entity');
+    });
+
+    it('should handle network errors when searching users', async () => {
+      // Mock network failure
+      mockFetch.mockRejectedValueOnce(new Error('Network failure'));
+
+      // Assert that the service throws an error
+      await expect(githubService.searchUsers('test')).rejects.toThrow('Network failure');
+    });
+
+    it('should properly encode search queries with special characters', async () => {
+      // Create mock search response
+      const mockSearchResponse = {
+        items: mockUsers,
+        total_count: mockUsers.length,
+        incomplete_results: false
+      };
+
+      // Mock successful response
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => mockSearchResponse,
+      });
+
+      const queryWithSpecialChars = 'test/user?';
+      await githubService.searchUsers(queryWithSpecialChars);
+      
+      // Assert fetch was called with properly encoded query
+      expect(mockFetch).toHaveBeenCalledWith(`https://api.github.com/search/users?q=${encodeURIComponent(queryWithSpecialChars)}`);
+    });
+  });
+
 });

--- a/src/modules/users/services/github-api.ts
+++ b/src/modules/users/services/github-api.ts
@@ -1,16 +1,17 @@
-import { GitHubUser, GitHubUserDetail } from '../github-types';
+import { GitHubUser } from '../github-types';
 
 const GITHUB_API_BASE_URL = 'https://api.github.com';
 
 export const githubQueryKeys = {
   users: () => ['github', 'users'],
   user: (username: string) => ['github', 'user', username],
+  searchUsers: (query: string) => ['github', 'search', 'users', query],
 };
 
 export class GitHubService {
-  async getUsers(): Promise<GitHubUser[]> {
+  private async fetchFromGitHub<T>(endpoint: string, errorMessage: string): Promise<T> {
     try {
-      const response = await fetch(`${GITHUB_API_BASE_URL}/users`);
+      const response = await fetch(`${GITHUB_API_BASE_URL}${endpoint}`);
       
       if (!response.ok) {
         throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
@@ -18,24 +19,32 @@ export class GitHubService {
       
       return await response.json();
     } catch (error) {
-      console.error('Failed to fetch GitHub users:', error);
+      console.error(errorMessage, error);
       throw error;
     }
   }
 
-  async getUserDetails(username: string): Promise<GitHubUserDetail> {
-    try {
-      const response = await fetch(`${GITHUB_API_BASE_URL}/users/${encodeURIComponent(username)}`);
-      
-      if (!response.ok) {
-        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
-      }
-      
-      return await response.json();
-    } catch (error) {
-      console.error(`Failed to fetch GitHub user details for ${username}:`, error);
-      throw error;
-    }
+  async getUsers(): Promise<GitHubUser[]> {
+    return this.fetchFromGitHub<GitHubUser[]>(
+      '/users',
+      'Failed to fetch GitHub users:'
+    );
+  }
+
+  async getUserDetails(username: string): Promise<GitHubUser> {
+    return this.fetchFromGitHub<GitHubUser>(
+      `/users/${encodeURIComponent(username)}`,
+      `Failed to fetch GitHub user details for ${username}:`
+    );
+  }
+
+  async searchUsers(query: string): Promise<GitHubUser[]> {
+    const request = await this.fetchFromGitHub<{ items: GitHubUser[], total_count: number, incomplete_results: boolean }>(
+      `/search/users?q=${encodeURIComponent(query)}`,
+      `Failed to search GitHub users for "${query}":`
+    );
+
+    return request.items;
   }
 }
 


### PR DESCRIPTION
- refactor: GitHubUser with optional props to handle only one type
- refactor: GitHubService with fetchFromGitHub and new searchUsers
- new search-input component
- new useDebounce hook
- useGitHubUsers dispatch services depend of query
- testing